### PR TITLE
Some supervisor rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Having deterministic fullstack in development has never been more awesome.
 
 Now build this with hydra and pass the environment around :)
 
+Alternative using nix-shell:
+
+- set `buildInputs = [ services.config.supervisord.bin ];`
+- run `nix-shell`
+- use `supervisord` and `supervisorctl` as you wish
 
 reContain - heroku@home
 -----------------------

--- a/nix-services/supervisord.nix
+++ b/nix-services/supervisord.nix
@@ -32,7 +32,35 @@ let
       };
     };
   };
+  
   services = config.supervisord.services;
+  
+  supervisor = config.supervisord.package;
+
+  supervisordWrapper = pkgs.writeScript "supervisord-wrapper" ''
+    #!${pkgs.stdenv.shell}
+    extraFlags=""
+    if [ -n "$STATEDIR" ]; then
+      extraFlags="-j $STATEDIR/run/supervisord.pid -d $STATEDIR -q $STATEDIR/log/ -l $STATEDIR/log/supervisord.log"
+      mkdir -p "$STATEDIR"/{run,log}
+    else
+      mkdir -p "${config.supervisord.stateDir}"/{run,log}
+    fi
+        
+    export PATH="${pkgs.coreutils}/bin"
+        
+    # Run start scripts first
+    ${config.userNix.startScript}
+        
+    # Run supervisord
+    ${supervisor}/bin/supervisord -c ${config.supervisord.configFile} $extraFlags $@
+  '';
+
+  supervisorctlWrapper = pkgs.writeScript "supervisorctl-wrapper" ''
+  	#!/usr/bin/env bash
+    ${supervisor}/bin/supervisorctl -c ${config.supervisord.configFile} $@
+  '';
+
 in {
   options = {
     supervisord = {
@@ -46,13 +74,29 @@ in {
         type = types.int;
       };
 
+      package = mkOption {
+        default = pkgs.pythonPackages.supervisor;
+        type = types.package;
+        description = ''
+          Supervisord package to use.
+        '';
+      };
+
       services = mkOption {
         default = {};
         type = types.loaOf types.optionSet;
         description = ''
-          Supervisord services to start
+          Supervisord services to start.
         '';
         options = [ serviceOpts ];
+      };
+
+      stateDir = mkOption {
+        default = "./var";
+        type = types.str;
+        description = ''
+          Supervisord state directory.
+        '';
       };
 
       tailLogs = mkOption {
@@ -63,13 +107,22 @@ in {
         '';
       };
 
-      configFile = mkOption {};
+      configFile = mkOption {
+        internal = true;
+      };
+
+      bin = mkOption {
+        internal = true;
+      };
     };
   };
 
   config = mkIf config.supervisord.enable {
     supervisord.configFile = pkgs.writeText "supervisord.conf" ''
       [supervisord]
+      pidfile=${config.supervisord.stateDir}/run/supervisord.pid
+      childlogdir=${config.supervisord.stateDir}/log/
+      logfile=${config.supervisord.stateDir}/log/supervisord.log
 
       [supervisorctl]
       serverurl = http://localhost:${toString config.supervisord.port}
@@ -86,7 +139,7 @@ in {
         in
           ''
           [program:${name}]
-          command=${if cfg.pidfile == null then cfg.command else "${pkgs.pythonPackages.supervisor}/bin/pidproxy ${cfg.pidfile} ${cfg.command}"}
+          command=${if cfg.pidfile == null then cfg.command else "${supervisor}/bin/pidproxy ${cfg.pidfile} ${cfg.command}"}
           environment=${concatStrings
             (mapAttrsToList (name: value: "${name}=\"${value}\",") (
               cfg.environment // { PATH = concatStringsSep ":"
@@ -103,5 +156,20 @@ in {
         ) (attrNames services)
       }
     '';
+
+    supervisord.bin = pkgs.stdenv.mkDerivation {
+      name = "${supervisor.name}-wrapper";
+
+      phases = [ "installPhase" ];
+
+      installPhase = ''
+        mkdir -p $out/bin/
+        ln -s -T ${supervisordWrapper} $out/bin/supervisord
+        ln -s -T ${supervisorctlWrapper} $out/bin/supervisorctl
+      '';
+
+    };
+
   };
 }
+  


### PR DESCRIPTION
- Add supervisord.package
- Add supervisord.stateDir
- Set pidfile, logdir and childlogdir in the config,
  to make it easier from command line to override
  the single values
- Create a wrapper for supervisord and supervisorctl
- Only pass flags to supervisord if STATEDIR is non-empty
- Allow passing custom flags to supervisord and supervisorctl
- Add passthru.config to the resulting env
- Use stdenv.shell, because /bin/sh shebang is not patched

The config.supervisord.bin is very useful in nix dev environments,
where you can just run supervisord to start all services and
supervisorctl to manage the services.

Also setting a config.supervisord.stateDir allows to run
supervisord from any directory in nix-shell. Useful if you
have multiple clones of your repository, and still want to
share the services state.
