### PR TITLE
fix services.<name>.path to work both with list and string

### DIFF
--- a/nix-services/supervisord.nix
+++ b/nix-services/supervisord.nix
@@ -136,6 +136,7 @@ in {
       ${concatMapStrings (name:
         let
           cfg = getAttr name services;
+		  path = if isList cfg.path then concatStringsSep ":" cfg.path else cfg.path;
         in
           ''
           [program:${name}]
@@ -143,7 +144,7 @@ in {
           environment=${concatStrings
             (mapAttrsToList (name: value: "${name}=\"${value}\",") (
               cfg.environment // { PATH = concatStringsSep ":"
-                [("%(ENV_PATH)s") (cfg.path) (maybeAttr "PATH" "" cfg.environment)];
+                [("%(ENV_PATH)s") (path) (maybeAttr "PATH" "" cfg.environment)];
               }
             )
           )}


### PR DESCRIPTION
Happened when writing my own services, where path = []. The current code assumes it's a string but sometimes it's not.
